### PR TITLE
Make sure the variable path is never empty

### DIFF
--- a/docs/menu.js
+++ b/docs/menu.js
@@ -31,7 +31,13 @@ document.write(`
 `)
 
 //select/toggle the correct language from the dropdown after making a selection (there might be a better way to do this?)
-var path = window.location.pathname.split("/").pop();
+//If path points to a directory, user agent will open the "index.html"
+//file in it, but will not append it to the window's path name. So treat
+//"" as "index.html"
+var path = window.location.pathname.split("/").pop()
+if(path === ""){
+  path = "index.html";
+}
 var lang = path.split(".")[0]
 // console.log( lang );
 document.querySelector(`option[value=${lang}]`).selected = true


### PR DESCRIPTION
Fixes #34.

# Where does the problem come from? # 
The link available in @bmoren 's repository, points to a directory instead of a file. This is not actually a problem, it is common and servers, by default, search for "index.html" or "index.htm" in that directory and return one of them if found, but **without updating** the window's URL.

# What the actual problem is #
The _menu.js_ script relies on the window's URL having the file served, which may not be the case as explained before, to find out which page was served and set the corresponding option to selected, in the dropdown menu. Without the doc's name in the URL, the script crashes and can't get to subscribe the printing icon to the clicking event.

I hope this explanation is clear and concise enough :).